### PR TITLE
Modernize addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ The utility can also compact and expand a **GUID** into and from a **string** us
 A compact **GUID** is beneficial for shorter urls and for smaller transfers.
 
 
-## Requirements
-`compact()` and `expand()` require IE10 or polyfill for `atob` and `btoa`.
-
-
 ## Example
 ```
-import Guid from 'ember-cli-guid';
+import { compactGuid, createGuid, expandGuid } from 'ember-cli-guid';
 
-let myGuid = Guid.create(); // '13ab9d6a-9aa4-40da-ae0d-21181c373e18'
-let myCompactedGuid = Guid.compact(myGuid); // 'ap2rE6Sa2kCuDSEYHDc-GA'
-let myExpandedGuid = Guid.expand(myCompactedGuid); // '13ab9d6a-9aa4-40da-ae0d-21181c373e18'
+let myGuid = createGuid(); // '13ab9d6a-9aa4-40da-ae0d-21181c373e18'
+let myCompactedGuid = compactGuid(myGuid); // 'ap2rE6Sa2kCuDSEYHDc-GA'
+let myExpandedGuid = expandGuid(myCompactedGuid); // '13ab9d6a-9aa4-40da-ae0d-21181c373e18'
+```
+
+Note: `createGuid` can return a compact **GUID**:
+```
+createGuid(true); // 'kFy4uun_BkaUdbSGYW1PYQ'
 ```
 
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,2 +1,2 @@
 // Allow direct import ('ember-cli-guid')
-export { default } from './utils/guid';
+export * from './utils/guid';

--- a/addon/utils/guid.js
+++ b/addon/utils/guid.js
@@ -1,64 +1,63 @@
-import EmberObject from '@ember/object';
-import { A } from '@ember/array';
-import { isNone } from '@ember/utils';
-
 const GUID = /^[0-9a-f]{8}-?([0-9a-f]{4}-?){3}[0-9a-f]{12}$/i;
 
-export default EmberObject.create({
-  create() {
-    let guid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
+export function createGuid(compact = false) {
+  let guid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx';
 
-    guid = guid.replace(/[xy]/g, c => {
-      let rnd = Math.random() * 16 | 0;
-      let v = c === 'x' ? rnd : (rnd & 0x3 | 0x8);
-      return v.toString(16);
-    });
+  guid = guid.replace(/[xy]/g, c => {
+    let rnd = Math.random() * 16 | 0;
+    let v = c === 'x' ? rnd : (rnd & 0x3 | 0x8);
+    return v.toString(16);
+  });
 
-    return guid;
-  },
+  return compact ? compactGuid(guid) : guid;
+}
 
-  compact(guid) {
-    if (!new RegExp(GUID).test(guid)) {
-      return;
-    }
-
-    let g = guid.replace(/-/g, '');
-    let rguid = g.substring(6, 8) + g.substring(4, 6) +
-      g.substring(2, 4) + g.substring(0, 2) +
-      g.substring(10, 12) + g.substring(8, 10) +
-      g.substring(14, 16) + g.substring(12, 14) + g.substring(16);
-
-    let hex = rguid
-        .replace(/\r|\n/g, '')
-        .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
-        .replace(/ +$/, '')
-        .split(' ');
-
-    let bytes = String.fromCharCode(...hex);
-    let base64 = btoa(bytes);
-
-    return base64.replace(/=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
-  },
-
-  expand(cguid) {
-    if (isNone(cguid) || cguid.length !== 22) {
-      return;
-    }
-
-    let base64 = `${cguid.replace(/_/g, '/').replace(/-/g, '+')}==`;
-    let bytes = atob(base64);
-    let g = [];
-
-    for (let i = 0; i < bytes.length; i++) {
-      let item = bytes.charCodeAt(i);
-      g.push(`00${item.toString(16).toLowerCase()}`.substr(-2, 2));
-    }
-
-    let guid = A(g.slice(0, 4).reverse().concat(g.slice(4, 6).reverse())
-      .concat(g.slice(6, 8).reverse()).concat(g.slice(8)));
-
-    guid.insertAt(4, '-').insertAt(7, '-').insertAt(10, '-').insertAt(13, '-');
-
-    return guid.join('');
+export function compactGuid(guid) {
+  if (!new RegExp(GUID).test(guid)) {
+    return;
   }
-});
+
+  let g = guid.replace(/-/g, '');
+  let rguid = g.substring(6, 8) + g.substring(4, 6) +
+    g.substring(2, 4) + g.substring(0, 2) +
+    g.substring(10, 12) + g.substring(8, 10) +
+    g.substring(14, 16) + g.substring(12, 14) + g.substring(16);
+
+  let hex = rguid
+    .replace(/\r|\n/g, '')
+    .replace(/([\da-fA-F]{2}) ?/g, '0x$1 ')
+    .replace(/ +$/, '')
+    .split(' ');
+
+  let bytes = String.fromCharCode(...hex);
+  let base64 = btoa(bytes);
+
+  return base64.replace(/=/g, '').replace(/\//g, '_').replace(/\+/g, '-');
+}
+
+export function expandGuid(cguid) {
+  if (!cguid || cguid.length !== 22) {
+    return;
+  }
+
+  let base64 = `${cguid.replace(/_/g, '/').replace(/-/g, '+')}==`;
+  let bytes = atob(base64);
+  let g = [];
+
+  for (let i = 0; i < bytes.length; i++) {
+    let item = bytes.charCodeAt(i);
+    g.push(`00${item.toString(16).toLowerCase()}`.substr(-2, 2));
+  }
+
+  return g.slice(0, 4)
+    .reverse()
+    .concat('-')
+    .concat(g.slice(4, 6).reverse())
+    .concat('-')
+    .concat(g.slice(6, 8).reverse())
+    .concat('-')
+    .concat(g.slice(8, 10))
+    .concat('-')
+    .concat(g.slice(10))
+    .join('');
+}

--- a/app/utils/guid.js
+++ b/app/utils/guid.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-cli-guid/utils/guid';
+export * from 'ember-cli-guid/utils/guid';


### PR DESCRIPTION
- Convert to straight utilities to avoid allocating an `EmberObject`.
- Do not rely on `EmberArray` or `isNone`.
- Support generating a compacted `Guid`.